### PR TITLE
Rename environment to workspace.

### DIFF
--- a/terraform/data_source_state.go
+++ b/terraform/data_source_state.go
@@ -37,7 +37,7 @@ func dataSourceRemoteState() *schema.Resource {
 				Optional: true,
 			},
 
-			"environment": {
+			"workspace": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  backend.DefaultStateName,
@@ -80,8 +80,8 @@ func dataSourceRemoteStateRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Get the state
-	env := d.Get("environment").(string)
-	state, err := b.State(env)
+	workspace := d.Get("workspace").(string)
+	state, err := b.State(workspace)
 	if err != nil {
 		return fmt.Errorf("error loading the remote state: %s", err)
 	}

--- a/website/docs/d/remote_state.html.md
+++ b/website/docs/d/remote_state.html.md
@@ -31,7 +31,7 @@ resource "aws_instance" "foo" {
 The following arguments are supported:
 
 * `backend` - (Required) The remote backend to use.
-* `environment` - (Optional) The Terraform environment to use.
+* `workspace` - (Optional) The Terraform workspace to use.
 * `config` - (Optional) The configuration of the remote backend.
  * Remote state config docs can be found [here](/docs/backends/types/terraform-enterprise.html)
 


### PR DESCRIPTION
Follow up with the recent rename from environments to workspaces. I was initially confused when I tried to use `workspace` with `terraform_remote_state` and it failed. Looking at the docs showed they were still referencing `environment`, this PR corrects that behavior and documentation.