### PR TITLE
Adding a defaults section to terraform_remote_state

### DIFF
--- a/terraform/data_source_state_test.go
+++ b/terraform/data_source_state_test.go
@@ -63,6 +63,38 @@ func TestState_complexOutputs(t *testing.T) {
 	})
 }
 
+func TestEmptyState_defaults(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmptyState_defaults,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue(
+						"data.terraform_remote_state.foo", "foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func TestState_defaults(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmptyState_defaults,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue(
+						"data.terraform_remote_state.foo", "foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[id]
@@ -107,5 +139,31 @@ resource "terraform_remote_state" "foo" {
 
 	config {
 		path = "./test-fixtures/complex_outputs.tfstate"
+	}
+}`
+
+const testAccEmptyState_defaults = `
+data "terraform_remote_state" "foo" {
+	backend = "local"
+
+	config {
+		path = "./test-fixtures/empty.tfstate"
+	}
+
+	defaults {
+		foo = "bar"
+	}
+}`
+
+const testAccState_defaults = `
+data "terraform_remote_state" "foo" {
+	backend = "local"
+
+	config {
+		path = "./test-fixtures/basic.tfstate"
+	}
+
+	defaults {
+		foo = "not bar"
 	}
 }`

--- a/website/docs/d/remote_state.html.md
+++ b/website/docs/d/remote_state.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `backend` - (Required) The remote backend to use.
 * `environment` - (Optional) The Terraform environment to use.
 * `config` - (Optional) The configuration of the remote backend.
-* `defaults` - (Optional) default output values in case state file is still empty or it does not have the output. It is in form of a map.
+* `defaults` - (Optional) default value for outputs in case state file is empty or it does not have the output.
  * Remote state config docs can be found [here](/docs/backends/types/terraform-enterprise.html)
 
 ## Attributes Reference

--- a/website/docs/d/remote_state.html.md
+++ b/website/docs/d/remote_state.html.md
@@ -33,6 +33,7 @@ The following arguments are supported:
 * `backend` - (Required) The remote backend to use.
 * `environment` - (Optional) The Terraform environment to use.
 * `config` - (Optional) The configuration of the remote backend.
+* `defaults` - (Optional) default output values in case they are not defined in state file. It is in form of a map.
  * Remote state config docs can be found [here](/docs/backends/types/terraform-enterprise.html)
 
 ## Attributes Reference

--- a/website/docs/d/remote_state.html.md
+++ b/website/docs/d/remote_state.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `backend` - (Required) The remote backend to use.
 * `environment` - (Optional) The Terraform environment to use.
 * `config` - (Optional) The configuration of the remote backend.
-* `defaults` - (Optional) default output values in case they are not defined in state file. It is in form of a map.
+* `defaults` - (Optional) default output values in case state file is still empty or it does not have the output. It is in form of a map.
  * Remote state config docs can be found [here](/docs/backends/types/terraform-enterprise.html)
 
 ## Attributes Reference


### PR DESCRIPTION
Adding a `defaults` section to `terraform_remote_state` can clean up the process we have in our team.

We are using remote state-file. With that we can simply clone our terraform repo and work on it. Except that we need to distribute the secret variables we use somehow.

But actually almost all secrets which we need is stored in state file and we all have access to state file. We just need to reuse those if we are working on a non-empty state. We dont need to resupply all our secret again.

One easy way we found is by using `data.terraform_remote_state`.

```hcl
data "terraform_remote_state" "k8s" {
  backend = "local"

  config {
    path = "terraform.tfstate"
  }
}

variable "my_secret" {
  default = ""
}

resource "local_file" "my_dummy_secret_consumer" {
  content  = "${var.my_secret != "" ? var.my_secret : data.terraform_remote_state.k8s.my_secret}"
  filename = "/tmp/this_is_just_to_save_someting"
}
output "my_secret" {
  value = "${var.my_secret != "" ? var.my_secret : data.terraform_remote_state.k8s.my_secret}"
}
```

The above code actually works for us right now. We don't need to store the secrets locally or distribute them in our team. 

But only if state-file has the output already (a chicken and egg situation) so we do some dirty change when we add a new secret or if state is empty.

I have the following change compiled and with that we can have a very clean setup (by adding a defaults section).

```hcl
data "terraform_remote_state" "k8s" {
  backend = "local"

  config {
    path = "terraform.tfstate"
  }

  defaults {
    my_secret = "if_var_not_set_and_state_is_empty"
  }
}

variable "my_secret" {
  default = ""
}

resource "local_file" "my_dummy_secret_consumer" {
  content  = "${var.my_secret != "" ? var.my_secret : data.terraform_remote_state.k8s.my_secret}"
  filename = "/tmp/this_is_just_to_save_someting"
}
output "my_secret" {
  value = "${var.my_secret != "" ? var.my_secret : data.terraform_remote_state.k8s.my_secret}"
}
```

This works perfectly, our setup won't break anymore if state is empty. and we don't need to spend time on any other solutions. Terraform in a sufficient solution by itself this way.

 Adding this change will help me greatly and I am hoping that this method might be useful for others too.
